### PR TITLE
Removed no longer existing parameter for BurntToastNotifier '-AppId'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>fr.jcgay.send-notification</groupId>
     <artifactId>send-notification-project</artifactId>
-    <version>0.15.1-SNAPSHOT</version>
+    <version>0.15.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Send Notification Project</name>
     <description>Easily send notification to popular tools and services</description>
@@ -58,37 +58,45 @@
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>build-with-toolchains</id>
-            <activation>
-                <jdk>!1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>${maven.compiler.target}</version>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+    <!--<profiles>-->
+        <!--<profile>-->
+            <!--<id>build-with-toolchains</id>-->
+            <!--<activation>-->
+                <!--<jdk>!1.8</jdk>-->
+            <!--</activation>-->
+            <!--<build>-->
+                <!--<plugins>-->
+                    <!--<plugin>-->
+                        <!--<artifactId>maven-toolchains-plugin</artifactId>-->
+                        <!--<executions>-->
+                            <!--<execution>-->
+                                <!--<goals>-->
+                                    <!--<goal>toolchain</goal>-->
+                                <!--</goals>-->
+                            <!--</execution>-->
+                        <!--</executions>-->
+                        <!--<configuration>-->
+                            <!--<toolchains>-->
+                                <!--<jdk>-->
+                                    <!--<version>${maven.compiler.target}</version>-->
+                                <!--</jdk>-->
+                            <!--</toolchains>-->
+                        <!--</configuration>-->
+                    <!--</plugin>-->
+                <!--</plugins>-->
+            <!--</build>-->
+        <!--</profile>-->
+    <!--</profiles>-->
 
 </project>

--- a/send-notification-cli/pom.xml
+++ b/send-notification-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>fr.jcgay.send-notification</groupId>
         <artifactId>send-notification-project</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.15.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>send-notification-cli</artifactId>

--- a/send-notification/pom.xml
+++ b/send-notification/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>fr.jcgay.send-notification</groupId>
         <artifactId>send-notification-project</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.15.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>send-notification</artifactId>

--- a/send-notification/src/main/java/fr/jcgay/notification/notifier/burnttoast/BurntToastNotifier.java
+++ b/send-notification/src/main/java/fr/jcgay/notification/notifier/burnttoast/BurntToastNotifier.java
@@ -32,10 +32,7 @@ public class BurntToastNotifier implements DiscoverableNotifier {
             .append("', '")
             .append(notification.message())
             .append("' -AppLogo ")
-            .append(notification.icon().asPath())
-            .append(" -AppId '")
-            .append(application.id())
-            .append("'");
+            .append(notification.icon().asPath());
 
         if (configuration.sound() == null) {
             command.append(" -Silent");


### PR DESCRIPTION
I couldn't let it compile with your jdk 1.8 toolchain configuration so I commented it out.
And: Groovy didn't work, so it fails when it tries to compile the tests, otherwise I just increased the minor version number by 1 and removed the outdated call in BurntToastNotifier for '-AppId'.